### PR TITLE
ウォッチャー追加時にロールのフィルタができない件を修正

### DIFF
--- a/lib/redmine_watcher_filter/watchers_controller_patch.rb
+++ b/lib/redmine_watcher_filter/watchers_controller_patch.rb
@@ -37,7 +37,7 @@ module WatcherFilter
       end
       if params[:role_id].present?
         scope = scope.joins(:members => :roles).
-                  where("#{Role.table_name}.id = ?", params[:role_id]).uniq
+                  where("#{Role.table_name}.id = ?", params[:role_id]).distinct
       end
       scope
     end


### PR DESCRIPTION
下記の環境でプラグインバージョン4.0.0-alphaを使用したところ、ウォッチャー追加時のロールのフィルタができなくなっていましたので修正いたしました。
Rails 5.2.4.1
ruby 2.6.5p114
Redmine4.1.0

上記の環境でのみ動作確認を行っております。

ロールのフィルタはwatchers_controller_patch.rbの修正のみで可能になりましたのでこれでプルリクをいたしますが、
watchers_helper_patch.rbにもuniqが使用されている箇所がありますので、もし必要であれば修正くださればと思います。